### PR TITLE
Fix off-by-one in TXT records publication

### DIFF
--- a/glue.go
+++ b/glue.go
@@ -80,7 +80,7 @@ func zoneName(ifindex IfIndex) string {
 func makeAvahiStringList(txt []string) (*C.AvahiStringList, error) {
 	var ctxt *C.AvahiStringList
 
-	for i := len(txt) - 1; i > 0; i-- {
+	for i := len(txt) - 1; i >= 0; i-- {
 		b := []byte(txt[i])
 
 		prev := ctxt


### PR DESCRIPTION
There is an off-by-one in `makeAvahiStringList` which always skips the first TXT record provided. The workaround is to prepend the list of TXT records with an empty string. 