### PR TITLE
Add Go fuzz tests for DNS record decoding in go-avahi

### DIFF
--- a/dns_fuzz_test.go
+++ b/dns_fuzz_test.go
@@ -1,0 +1,80 @@
+//go:build linux || freebsd
+
+package avahi
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func FuzzDNSDecodeA(f *testing.F) {
+	// Valid IPv4
+	f.Add([]byte{127, 0, 0, 1})
+	f.Add([]byte{8, 8, 8, 8})
+
+	// Invalid sizes
+	f.Add([]byte{})
+	f.Add([]byte{1})
+	f.Add([]byte{1, 2, 3})
+	f.Add([]byte{1, 2, 3, 4, 5})
+
+	// Random bytes
+	f.Add([]byte{255, 255, 255, 255})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		addr := DNSDecodeA(data)
+
+		if addr.IsValid() && addr.Is6() {
+			t.Fatalf("DNSDecodeA returned IPv6 address: %v", addr)
+		}
+	})
+}
+
+func FuzzDNSDecodeAAAA(f *testing.F) {
+	// Valid IPv6 (loopback)
+	f.Add(netip.IPv6Loopback().AsSlice())
+
+	// Invalid sizes
+	f.Add([]byte{})
+	f.Add([]byte{1, 2, 3})
+	f.Add(make([]byte, 15))
+	f.Add(make([]byte, 17))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		addr := DNSDecodeAAAA(data)
+
+		if addr.IsValid() && !addr.Is6() {
+			t.Fatalf("DNSDecodeAAAA returned non-IPv6 address: %v", addr)
+		}
+	})
+}
+
+func FuzzDNSDecodeTXT(f *testing.F) {
+	// Valid TXT records
+	f.Add([]byte{3, 'f', 'o', 'o'})
+	f.Add([]byte{3, 'f', 'o', 'o', 3, 'b', 'a', 'r'})
+
+	// Empty string
+	f.Add([]byte{0})
+
+	// Length exceeds data
+	f.Add([]byte{10, 'a'})
+
+	// Nested garbage
+	f.Add([]byte{255, 255, 255})
+
+	// Random bytes
+	f.Add([]byte{1, 0, 255, 10, 20, 30})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		txt := DNSDecodeTXT(data)
+
+		if txt != nil {
+			for _, s := range txt {
+				if len(s) == 0 {
+					t.Fatalf("DNSDecodeTXT returned empty string")
+				}
+			}
+		}
+	})
+}

--- a/dns_fuzz_test.go
+++ b/dns_fuzz_test.go
@@ -1,3 +1,10 @@
+// CGo binding for Avahi
+//
+// Copyright (C) 2025 by Prashant Andoriya
+// See LICENSE for license terms and conditions
+//
+// Fuzz tests for DNS record decoding functions
+//
 //go:build linux || freebsd
 
 package avahi
@@ -7,6 +14,7 @@ import (
 	"testing"
 )
 
+// FuzzDNSDecodeA fuzzes the DNSDecodeA function
 func FuzzDNSDecodeA(f *testing.F) {
 	// Valid IPv4
 	f.Add([]byte{127, 0, 0, 1})
@@ -30,6 +38,7 @@ func FuzzDNSDecodeA(f *testing.F) {
 	})
 }
 
+// FuzzDNSDecodeAAAA fuzzes the DNSDecodeAAAA function
 func FuzzDNSDecodeAAAA(f *testing.F) {
 	// Valid IPv6 (loopback)
 	f.Add(netip.IPv6Loopback().AsSlice())
@@ -49,6 +58,7 @@ func FuzzDNSDecodeAAAA(f *testing.F) {
 	})
 }
 
+// FuzzDNSDecodeTXT fuzzes the DNSDecodeTXT function
 func FuzzDNSDecodeTXT(f *testing.F) {
 	// Valid TXT records
 	f.Add([]byte{3, 'f', 'o', 'o'})


### PR DESCRIPTION
## Description

This PR adds the first set of native Go fuzz tests to go-avahi, focusing on DNS record decoding logic. These paths process external mDNS/DNS-SD data and are high value targets for fuzzing due to their exposure to malformed or adversarial input.

## What’s included

Fuzz tests for the following functions in dns.go:
- DNSDecodeA (A record)
- DNSDecodeAAAA (AAAA record)
- DNSDecodeTXT (TXT record)

The tests use Go’s built in fuzzing engine to detect panics, out of bounds access, and incorrect handling of malformed or truncated input.

## Test results 

```bash
prashant@LAPTOP-PBG53FVG:/mnt/d/go-avahi$ go test -run=^$ -fuzz=^FuzzDNSDecodeA$ -fuzztime=30s
fuzz: elapsed: 0s, gathering baseline coverage: 0/7 completed
fuzz: elapsed: 0s, gathering baseline coverage: 7/7 completed, now fuzzing with 8 workers
fuzz: elapsed: 3s, execs: 188935 (62693/sec), new interesting: 0 (total: 7)
fuzz: elapsed: 6s, execs: 321235 (44204/sec), new interesting: 0 (total: 7)
fuzz: elapsed: 9s, execs: 417673 (32189/sec), new interesting: 0 (total: 7)
fuzz: elapsed: 12s, execs: 528418 (36740/sec), new interesting: 0 (total: 7)
fuzz: elapsed: 15s, execs: 669720 (47352/sec), new interesting: 0 (total: 7)
fuzz: elapsed: 18s, execs: 806784 (45696/sec), new interesting: 0 (total: 7)
fuzz: elapsed: 21s, execs: 941590 (44785/sec), new interesting: 0 (total: 7)
fuzz: elapsed: 24s, execs: 1077992 (45504/sec), new interesting: 0 (total: 7)
fuzz: elapsed: 27s, execs: 1231578 (51253/sec), new interesting: 0 (total: 7)
fuzz: elapsed: 30s, execs: 1400273 (56289/sec), new interesting: 0 (total: 7)
fuzz: elapsed: 31s, execs: 1400273 (0/sec), new interesting: 0 (total: 7)
PASS
ok      github.com/OpenPrinting/go-avahi        30.736s
prashant@LAPTOP-PBG53FVG:/mnt/d/go-avahi$ go test -run=^$ -fuzz=^FuzzDNSDecodeAAAA$ -fuzztime=30s
fuzz: elapsed: 0s, gathering baseline coverage: 0/6 completed
fuzz: elapsed: 0s, gathering baseline coverage: 6/6 completed, now fuzzing with 8 workers
fuzz: elapsed: 3s, execs: 220446 (73475/sec), new interesting: 0 (total: 6)
fuzz: elapsed: 6s, execs: 449727 (76394/sec), new interesting: 0 (total: 6)
fuzz: elapsed: 9s, execs: 686149 (78787/sec), new interesting: 0 (total: 6)
fuzz: elapsed: 12s, execs: 954418 (89479/sec), new interesting: 0 (total: 6)
fuzz: elapsed: 15s, execs: 1178695 (74566/sec), new interesting: 0 (total: 6)
fuzz: elapsed: 18s, execs: 1414814 (78759/sec), new interesting: 0 (total: 6)
fuzz: elapsed: 21s, execs: 1683482 (89727/sec), new interesting: 0 (total: 6)
fuzz: elapsed: 24s, execs: 1907625 (74710/sec), new interesting: 0 (total: 6)
fuzz: elapsed: 27s, execs: 2128413 (73594/sec), new interesting: 0 (total: 6)
fuzz: elapsed: 30s, execs: 2367905 (79850/sec), new interesting: 0 (total: 6)
fuzz: elapsed: 31s, execs: 2367905 (0/sec), new interesting: 0 (total: 6)
PASS
ok      github.com/OpenPrinting/go-avahi        31.293s
prashant@LAPTOP-PBG53FVG:/mnt/d/go-avahi$ go test -run=^$ -fuzz=^FuzzDNSDecodeTXT$ -fuzztime=60s
fuzz: elapsed: 0s, gathering baseline coverage: 0/14 completed
fuzz: elapsed: 0s, gathering baseline coverage: 14/14 completed, now fuzzing with 8 workers
fuzz: elapsed: 3s, execs: 39702 (13229/sec), new interesting: 1 (total: 15)
fuzz: elapsed: 6s, execs: 39702 (0/sec), new interesting: 1 (total: 15)
fuzz: elapsed: 9s, execs: 237114 (65974/sec), new interesting: 2 (total: 16)
fuzz: elapsed: 12s, execs: 402992 (55282/sec), new interesting: 2 (total: 16)
fuzz: elapsed: 15s, execs: 402992 (0/sec), new interesting: 2 (total: 16)
fuzz: elapsed: 18s, execs: 402992 (0/sec), new interesting: 2 (total: 16)
fuzz: elapsed: 21s, execs: 402992 (0/sec), new interesting: 2 (total: 16)
fuzz: elapsed: 24s, execs: 402992 (0/sec), new interesting: 2 (total: 16)
fuzz: elapsed: 27s, execs: 713899 (103629/sec), new interesting: 2 (total: 16)
fuzz: elapsed: 30s, execs: 720421 (2170/sec), new interesting: 2 (total: 16)
fuzz: elapsed: 33s, execs: 720421 (0/sec), new interesting: 2 (total: 16)
fuzz: elapsed: 36s, execs: 720421 (0/sec), new interesting: 2 (total: 16)
fuzz: elapsed: 39s, execs: 1130596 (136964/sec), new interesting: 3 (total: 17)
fuzz: elapsed: 42s, execs: 1446988 (105530/sec), new interesting: 3 (total: 17)
fuzz: elapsed: 45s, execs: 1446988 (0/sec), new interesting: 3 (total: 17)
fuzz: elapsed: 48s, execs: 1446988 (0/sec), new interesting: 3 (total: 17)
fuzz: elapsed: 51s, execs: 1446988 (0/sec), new interesting: 3 (total: 17)
fuzz: elapsed: 54s, execs: 1446988 (0/sec), new interesting: 3 (total: 17)
fuzz: elapsed: 57s, execs: 1446988 (0/sec), new interesting: 3 (total: 17)
fuzz: elapsed: 1m0s, execs: 1446988 (0/sec), new interesting: 3 (total: 17)
fuzz: elapsed: 1m1s, execs: 1446988 (0/sec), new interesting: 3 (total: 17)
PASS
ok      github.com/OpenPrinting/go-avahi        61.142s
```