### PR TITLE
Add fuzz tests for lookup flag string formatting

### DIFF
--- a/lookupflags_test.go
+++ b/lookupflags_test.go
@@ -1,0 +1,59 @@
+//go:build linux || freebsd
+
+package avahi
+
+import (
+	"strings"
+	"testing"
+)
+
+func FuzzLookupFlagsString(f *testing.F) {
+	// Valid combinations
+	f.Add(int(LookupUseWideArea))
+	f.Add(int(LookupUseMulticast))
+	f.Add(int(LookupNoTXT))
+	f.Add(int(LookupNoAddress))
+	f.Add(int(LookupUseWideArea | LookupNoTXT))
+	f.Add(int(0))
+
+	// Invalid / random combinations
+	f.Add(-1)
+	f.Add(1 << 30)
+	f.Add(0xffffffff)
+
+	f.Fuzz(func(t *testing.T, v int) {
+		flags := LookupFlags(v)
+		s := flags.String()
+
+		if strings.Contains(s, " ") {
+			t.Fatalf("LookupFlags.String() returned invalid string: %q", s)
+		}
+	})
+}
+
+func FuzzLookupResultFlagsString(f *testing.F) {
+	// Valid flags
+	f.Add(int(LookupResultCached))
+	f.Add(int(LookupResultWideArea))
+	f.Add(int(LookupResultMulticast))
+	f.Add(int(LookupResultLocal))
+	f.Add(int(LookupResultOurOwn))
+	f.Add(int(LookupResultStatic))
+	f.Add(int(0))
+
+	// Invalid / random combinations
+	f.Add(-1)
+	f.Add(1 << 29)
+	f.Add(0xffffffff)
+
+	f.Fuzz(func(t *testing.T, v int) {
+		flags := LookupResultFlags(v)
+		s := flags.String()
+
+		// String() must never panic
+		// Ensure no empty tokens like ",,"
+		if strings.Contains(s, ",,") {
+			t.Fatalf("LookupResultFlags.String() returned malformed string: %q", s)
+		}
+	})
+}

--- a/lookupflags_test.go
+++ b/lookupflags_test.go
@@ -1,3 +1,10 @@
+// CGo binding for Avahi
+//
+// Copyright (C) 2025 by Prashant Andoriya
+// See LICENSE for license terms and conditions
+//
+// Fuzz tests for Avahi lookup flag string formatting.
+//
 //go:build linux || freebsd
 
 package avahi
@@ -7,6 +14,7 @@ import (
 	"testing"
 )
 
+// FuzzLookupFlagsString fuzzes the LookupFlags.String method
 func FuzzLookupFlagsString(f *testing.F) {
 	// Valid combinations
 	f.Add(int(LookupUseWideArea))
@@ -31,6 +39,7 @@ func FuzzLookupFlagsString(f *testing.F) {
 	})
 }
 
+// FuzzLookupResultFlagsString fuzzes the LookupResultFlags.String method
 func FuzzLookupResultFlagsString(f *testing.F) {
 	// Valid flags
 	f.Add(int(LookupResultCached))


### PR DESCRIPTION
## Description

This PR adds Go fuzz tests for LookupFlags.String() and LookupResultFlags.String() to improve coverage of flag parsing and string formatting logic.

The fuzzers exercise valid, invalid, and adversarial flag combinations to ensure these methods handle unknown bits safely, produce well formed output, and never panic.

## Test Result

```bash
prashant@LAPTOP-PBG53FVG:/mnt/d/go-avahi$ go test -run=^$ -fuzz=^FuzzLookupFlagsString$ -fuzztime=30s
fuzz: elapsed: 0s, gathering baseline coverage: 0/9 completed
fuzz: elapsed: 0s, gathering baseline coverage: 9/9 completed, now fuzzing with 8 workers
fuzz: elapsed: 3s, execs: 223768 (74581/sec), new interesting: 7 (total: 16)
fuzz: elapsed: 6s, execs: 454017 (76574/sec), new interesting: 9 (total: 18)
fuzz: elapsed: 9s, execs: 672876 (73113/sec), new interesting: 11 (total: 20)
fuzz: elapsed: 12s, execs: 903881 (76993/sec), new interesting: 11 (total: 20)
fuzz: elapsed: 15s, execs: 1148669 (81597/sec), new interesting: 11 (total: 20)
fuzz: elapsed: 18s, execs: 1395796 (82392/sec), new interesting: 11 (total: 20)
fuzz: elapsed: 21s, execs: 1640188 (81335/sec), new interesting: 11 (total: 20)
fuzz: elapsed: 24s, execs: 1892614 (84180/sec), new interesting: 11 (total: 20)
fuzz: elapsed: 27s, execs: 2107370 (71656/sec), new interesting: 11 (total: 20)
fuzz: elapsed: 30s, execs: 2354594 (82411/sec), new interesting: 11 (total: 20)
fuzz: elapsed: 30s, execs: 2354594 (0/sec), new interesting: 11 (total: 20)
PASS
ok      github.com/OpenPrinting/go-avahi        30.089s
prashant@LAPTOP-PBG53FVG:/mnt/d/go-avahi$ go test -run=^$ -fuzz=^FuzzLookupResultFlagsString$ -fuzztime=30s
fuzz: elapsed: 0s, gathering baseline coverage: 0/10 completed
fuzz: elapsed: 0s, gathering baseline coverage: 10/10 completed, now fuzzing with 8 workers
fuzz: elapsed: 3s, execs: 203313 (67757/sec), new interesting: 7 (total: 17)
fuzz: elapsed: 6s, execs: 441118 (79241/sec), new interesting: 8 (total: 18)
fuzz: elapsed: 9s, execs: 670958 (76651/sec), new interesting: 8 (total: 18)
fuzz: elapsed: 12s, execs: 905637 (78200/sec), new interesting: 8 (total: 18)
fuzz: elapsed: 15s, execs: 1132415 (75615/sec), new interesting: 8 (total: 18)
fuzz: elapsed: 18s, execs: 1305403 (57639/sec), new interesting: 9 (total: 19)
fuzz: elapsed: 21s, execs: 1481600 (58617/sec), new interesting: 9 (total: 19)
fuzz: elapsed: 24s, execs: 1639031 (52499/sec), new interesting: 9 (total: 19)
fuzz: elapsed: 27s, execs: 1853469 (71619/sec), new interesting: 9 (total: 19)
fuzz: elapsed: 30s, execs: 2073899 (73473/sec), new interesting: 9 (total: 19)
fuzz: elapsed: 30s, execs: 2073899 (0/sec), new interesting: 9 (total: 19)
PASS
ok      github.com/OpenPrinting/go-avahi        30.161s
``` 