### PR TITLE
Improve robustness with unit and fuzz tests for core utilities

### DIFF
--- a/err_fuzz_test.go
+++ b/err_fuzz_test.go
@@ -1,0 +1,39 @@
+// CGo binding for Avahi
+//
+// Copyright (C) 2025 by Prashant Andoriya
+// See LICENSE for license terms and conditions
+//
+// Fuzz tests for Avahi error code string conversion
+//
+//go:build linux || freebsd
+
+package avahi
+
+import "testing"
+
+// FuzzErrCodeError fuzzes the ErrCode.Error method
+func FuzzErrCodeError(f *testing.F) {
+	// Valid error codes
+	f.Add(int(NoError))
+	f.Add(int(ErrFailure))
+	f.Add(int(ErrInvalidHostName))
+	f.Add(int(ErrTimeout))
+	f.Add(int(ErrInvalidFlags))
+	f.Add(int(ErrDNSNXDOMAIN))
+
+	// Invalid / adversarial values
+	f.Add(0)
+	f.Add(-1)
+	f.Add(1 << 29)
+	f.Add(0xffffffff)
+
+	f.Fuzz(func(t *testing.T, v int) {
+		err := ErrCode(v)
+		s := err.Error()
+
+		// Must never panic and must always return a non empty string
+		if s == "" {
+			t.Fatalf("ErrCode.Error() returned empty string for value %d", v)
+		}
+	})
+}

--- a/err_fuzz_test.go
+++ b/err_fuzz_test.go
@@ -11,7 +11,12 @@ package avahi
 
 import "testing"
 
-// FuzzErrCodeError fuzzes the ErrCode.Error method
+// FuzzErrCodeError fuzzes the ErrCode.Error method to verify that:
+//
+//   - it never panics for arbitrary integer values
+//   - it always returns a non empty string
+//
+// This is especially important because ErrCode.Error() crosses the Go - C boundary and relies on avahi_strerror()
 func FuzzErrCodeError(f *testing.F) {
 	// Valid error codes
 	f.Add(int(NoError))

--- a/err_test.go
+++ b/err_test.go
@@ -1,0 +1,46 @@
+// CGo binding for Avahi
+//
+// Copyright (C) 2025 by Prashant Andoriya
+// See LICENSE for license terms and conditions
+//
+// Unit tests for Avahi error code handling
+//
+//go:build linux || freebsd
+
+package avahi
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestErrCodeError verifies that Error() returns a prefixed error string
+func TestErrCodeError(t *testing.T) {
+	tests := []ErrCode{
+		NoError,
+		ErrFailure,
+		ErrInvalidHostName,
+		ErrInvalidDomainName,
+		ErrTimeout,
+		ErrInvalidFlags,
+		ErrDNSNXDOMAIN,
+	}
+
+	for _, ec := range tests {
+		s := ec.Error()
+		if s == "" {
+			t.Fatalf("ErrCode(%d).Error() returned empty string", ec)
+		}
+		if !strings.HasPrefix(s, "avahi: ") {
+			t.Fatalf("unexpected error prefix for ErrCode(%d): %q", ec, s)
+		}
+	}
+}
+
+// TestErrCodeImplementsError verifies ErrCode implements the error interface
+func TestErrCodeImplementsError(t *testing.T) {
+	var err error = ErrFailure
+	if err == nil {
+		t.Fatalf("ErrCode does not implement error interface")
+	}
+}

--- a/err_test.go
+++ b/err_test.go
@@ -14,7 +14,11 @@ import (
 	"testing"
 )
 
-// TestErrCodeError verifies that Error() returns a prefixed error string
+// TestErrCodeError verifies that ErrCode.Error() returns a non empty,
+//
+// The test intentionally does not assert the exact error message, as
+// the underlying string is provided by the Avahi C library and may
+// vary across versions or environments
 func TestErrCodeError(t *testing.T) {
 	tests := []ErrCode{
 		NoError,
@@ -37,7 +41,7 @@ func TestErrCodeError(t *testing.T) {
 	}
 }
 
-// TestErrCodeImplementsError verifies ErrCode implements the error interface
+// TestErrCodeImplementsError verifies that ErrCode satisfies the built in error interface, allowing it to be used transparently as a Go error value
 func TestErrCodeImplementsError(t *testing.T) {
 	var err error = ErrFailure
 	if err == nil {

--- a/err_test.go
+++ b/err_test.go
@@ -14,11 +14,14 @@ import (
 	"testing"
 )
 
-// TestErrCodeError verifies that ErrCode.Error() returns a non empty,
+// Compile time assertion that ErrCode implements the error interface.
+// This will fail to compile if ErrCode no longer satisfies error.
+var _ error = ErrFailure
+
+// TestErrCodeError verifies that ErrCode.Error() returns a non-empty,
 //
 // The test intentionally does not assert the exact error message, as
-// the underlying string is provided by the Avahi C library and may
-// vary across versions or environments
+// the underlying string is provided by the Avahi C library and may vary across versions or environments.
 func TestErrCodeError(t *testing.T) {
 	tests := []ErrCode{
 		NoError,
@@ -38,13 +41,5 @@ func TestErrCodeError(t *testing.T) {
 		if !strings.HasPrefix(s, "avahi: ") {
 			t.Fatalf("unexpected error prefix for ErrCode(%d): %q", ec, s)
 		}
-	}
-}
-
-// TestErrCodeImplementsError verifies that ErrCode satisfies the built in error interface, allowing it to be used transparently as a Go error value
-func TestErrCodeImplementsError(t *testing.T) {
-	var err error = ErrFailure
-	if err == nil {
-		t.Fatalf("ErrCode does not implement error interface")
 	}
 }

--- a/eventqueue_fuzz_test.go
+++ b/eventqueue_fuzz_test.go
@@ -1,0 +1,47 @@
+// CGo binding for Avahi
+//
+// Copyright (C) 2025 by Prashant Andoriya
+// See LICENSE for license terms and conditions
+//
+// Fuzz tests for eventqueue robustness
+//
+//go:build linux || freebsd
+
+package avahi
+
+import "testing"
+
+// FuzzEventQueueOperations fuzzes push and close operations on eventqueue
+func FuzzEventQueueOperations(f *testing.F) {
+	// Seed inputs
+	f.Add(0)
+	f.Add(1)
+	f.Add(10)
+	f.Add(100)
+
+	f.Fuzz(func(t *testing.T, n int) {
+		if n < 0 {
+			return
+		}
+		if n > 1000 {
+			n = 1000
+		}
+
+		var q eventqueue[int]
+		q.init()
+
+		// Push values
+		for i := 0; i < n; i++ {
+			q.Push(i)
+		}
+
+		// Drain some values (best effort)
+		for i := 0; i < n/2; i++ {
+			select {
+			case <-q.Chan():
+			default:
+			}
+		}
+		q.Close()
+	})
+}

--- a/eventqueue_test.go
+++ b/eventqueue_test.go
@@ -1,0 +1,99 @@
+// CGo binding for Avahi
+//
+// Copyright (C) 2025 by Prashant Andoriya
+// See LICENSE for license terms and conditions
+//
+// Unit tests for eventqueue behavior
+//
+//go:build linux || freebsd
+
+package avahi
+
+import (
+	"testing"
+	"time"
+)
+
+// TestEventQueueBasic verifies basic push and receive behavior
+func TestEventQueueBasic(t *testing.T) {
+	var q eventqueue[int]
+	q.init()
+
+	q.Push(1)
+	q.Push(2)
+	q.Push(3)
+
+	ch := q.Chan()
+
+	if v := <-ch; v != 1 {
+		t.Fatalf("expected 1, got %d", v)
+	}
+	if v := <-ch; v != 2 {
+		t.Fatalf("expected 2, got %d", v)
+	}
+	if v := <-ch; v != 3 {
+		t.Fatalf("expected 3, got %d", v)
+	}
+
+	q.Close()
+}
+
+// TestEventQueueClose verifies that Close eventually closes the output channel
+func TestEventQueueClose(t *testing.T) {
+	var q eventqueue[int]
+	q.init()
+
+	q.Push(42)
+	q.Close()
+
+	_, ok := <-q.Chan()
+	if ok {
+		t.Fatalf("expected channel to be closed after Close()")
+	}
+}
+
+func TestEventQueueCloseEventuallyCloses(t *testing.T) {
+	var q eventqueue[int]
+	q.init()
+
+	q.Push(1)
+	q.Push(2)
+	q.Push(3)
+
+	q.Close()
+
+	select {
+	case _, ok := <-q.Chan():
+		if ok {
+			_, ok = <-q.Chan()
+			if ok {
+				t.Fatalf("expected channel to be closed eventually after Close()")
+			}
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for channel to close")
+	}
+}
+
+// TestEventQueueMultiplePush verifies multiple pushes before reading
+func TestEventQueueMultiplePush(t *testing.T) {
+	var q eventqueue[int]
+	q.init()
+
+	for i := 0; i < 10; i++ {
+		q.Push(i)
+	}
+
+	for i := 0; i < 10; i++ {
+		select {
+		case v := <-q.Chan():
+			if v != i {
+				t.Fatalf("expected %d, got %d", i, v)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timeout waiting for value %d", i)
+		}
+	}
+
+	q.Close()
+}

--- a/protocol_fuzz_test.go
+++ b/protocol_fuzz_test.go
@@ -1,0 +1,46 @@
+// CGo binding for Avahi
+//
+// Copyright (C) 2025 by Prashant Andoriya
+// See LICENSE for license terms and conditions
+//
+// Fuzz tests for Protocol string conversion
+//
+//go:build linux || freebsd
+
+package avahi
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzProtocolString fuzzes the Protocol.String method
+func FuzzProtocolString(f *testing.F) {
+	// Valid protocol values
+	f.Add(int(ProtocolIP4))
+	f.Add(int(ProtocolIP6))
+	f.Add(int(ProtocolUnspec))
+
+	// Invalid / adversarial values
+	f.Add(0)
+	f.Add(-1)
+	f.Add(1 << 29)
+	f.Add(0xffffffff)
+
+	f.Fuzz(func(t *testing.T, v int) {
+		proto := Protocol(v)
+		s := proto.String()
+
+		// Must never panic and must always return a non empty string
+		if s == "" {
+			t.Fatalf("Protocol.String() returned empty string for value %d", v)
+		}
+
+		// For unknown values, String() should indicate UNKNOWN
+		if v != int(ProtocolIP4) && v != int(ProtocolIP6) && v != int(ProtocolUnspec) {
+			if !strings.HasPrefix(s, "UNKNOWN") {
+				t.Fatalf("unexpected string for unknown protocol %d: %q", v, s)
+			}
+		}
+	})
+}

--- a/protocol_fuzz_test.go
+++ b/protocol_fuzz_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-// FuzzProtocolString fuzzes the Protocol.String method
+// FuzzProtocolString fuzzes the Protocol.String method using valid, invalid, and extreme integer values
 func FuzzProtocolString(f *testing.F) {
 	// Valid protocol values
 	f.Add(int(ProtocolIP4))
@@ -36,7 +36,7 @@ func FuzzProtocolString(f *testing.F) {
 			t.Fatalf("Protocol.String() returned empty string for value %d", v)
 		}
 
-		// For unknown values, String() should indicate UNKNOWN
+		// For unknown values, String() should clearly indicate that the protocol is unsupported
 		if v != int(ProtocolIP4) && v != int(ProtocolIP6) && v != int(ProtocolUnspec) {
 			if !strings.HasPrefix(s, "UNKNOWN") {
 				t.Fatalf("unexpected string for unknown protocol %d: %q", v, s)

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -29,7 +29,9 @@ func TestProtocolString(t *testing.T) {
 	}
 }
 
-// TestProtocolStringUnknown verifies handling of unknown protocol values
+// TestProtocolStringUnknown verifies that unknown protocol values
+// are converted into a meaningful, non empty string that clearly
+// indicates an unsupported or unexpected protocol
 func TestProtocolStringUnknown(t *testing.T) {
 	p := Protocol(12345)
 	s := p.String()

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1,0 +1,44 @@
+// CGo binding for Avahi
+//
+// Copyright (C) 2025 by Prashant Andoriya
+// See LICENSE for license terms and conditions
+//
+// Unit tests for Protocol string conversion
+//
+//go:build linux || freebsd
+
+package avahi
+
+import "testing"
+
+// TestProtocolString verifies string output for known protocol values
+func TestProtocolString(t *testing.T) {
+	tests := []struct {
+		proto Protocol
+		want  string
+	}{
+		{ProtocolIP4, "ip4"},
+		{ProtocolIP6, "ip6"},
+		{ProtocolUnspec, "unspec"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.proto.String(); got != tt.want {
+			t.Fatalf("proto=%v: got %q, want %q", tt.proto, got, tt.want)
+		}
+	}
+}
+
+// TestProtocolStringUnknown verifies handling of unknown protocol values
+func TestProtocolStringUnknown(t *testing.T) {
+	p := Protocol(12345)
+	s := p.String()
+
+	if s == "" {
+		t.Fatalf("Protocol.String() returned empty string for unknown protocol")
+	}
+
+	if s[:7] != "UNKNOWN" {
+		t.Fatalf("unexpected string for unknown protocol: %q", s)
+	}
+}

--- a/publishiflags_fuzz_test.go
+++ b/publishiflags_fuzz_test.go
@@ -1,0 +1,49 @@
+// CGo binding for Avahi
+//
+// Copyright (C) 2025 by Prashant Andoriya
+// See LICENSE for license terms and conditions
+//
+// Fuzz tests for PublishFlags string formatting
+//
+//go:build linux || freebsd
+
+package avahi
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzPublishFlagsString fuzzes the PublishFlags.String method
+func FuzzPublishFlagsString(f *testing.F) {
+	// Valid flags
+	f.Add(int(PublishUnique))
+	f.Add(int(PublishNoProbe))
+	f.Add(int(PublishNoAnnounce))
+	f.Add(int(PublishAllowMultiple))
+	f.Add(int(PublishNoReverse))
+	f.Add(int(PublishNoCookie))
+	f.Add(int(PublishUpdate))
+	f.Add(int(PublishUseWideArea))
+	f.Add(int(PublishUseMulticast))
+	f.Add(int(0))
+
+	// Mixed / combined flags
+	f.Add(int(PublishUnique | PublishNoProbe | PublishUpdate))
+	f.Add(int(PublishUseWideArea | PublishUseMulticast))
+
+	// Invalid / adversarial values
+	f.Add(-1)
+	f.Add(1 << 30)
+	f.Add(0xffffffff)
+
+	f.Fuzz(func(t *testing.T, v int) {
+		flags := PublishFlags(v)
+		s := flags.String()
+
+		// Must never panic and must not contain malformed separators
+		if strings.Contains(s, ",,") {
+			t.Fatalf("PublishFlags.String() returned malformed string: %q", s)
+		}
+	})
+}

--- a/publishiflags_fuzz_test.go
+++ b/publishiflags_fuzz_test.go
@@ -14,9 +14,10 @@ import (
 	"testing"
 )
 
-// FuzzPublishFlagsString fuzzes the PublishFlags.String method
+// FuzzPublishFlagsString fuzzes the PublishFlags.String method with valid, mixed, and adversarial flag values.
 func FuzzPublishFlagsString(f *testing.F) {
 	// Valid flags
+	// Seed corpus with valid single flag values
 	f.Add(int(PublishUnique))
 	f.Add(int(PublishNoProbe))
 	f.Add(int(PublishNoAnnounce))
@@ -26,22 +27,24 @@ func FuzzPublishFlagsString(f *testing.F) {
 	f.Add(int(PublishUpdate))
 	f.Add(int(PublishUseWideArea))
 	f.Add(int(PublishUseMulticast))
-	f.Add(int(0))
+	f.Add(int(0)) // no flags
 
 	// Mixed / combined flags
 	f.Add(int(PublishUnique | PublishNoProbe | PublishUpdate))
 	f.Add(int(PublishUseWideArea | PublishUseMulticast))
 
-	// Invalid / adversarial values
+	// Invalid / adversarial values to test robustness
 	f.Add(-1)
 	f.Add(1 << 30)
 	f.Add(0xffffffff)
 
 	f.Fuzz(func(t *testing.T, v int) {
 		flags := PublishFlags(v)
+		// String() must never panic for any integer input
 		s := flags.String()
 
 		// Must never panic and must not contain malformed separators
+		// Output should never contain malformed separators such as double commas
 		if strings.Contains(s, ",,") {
 			t.Fatalf("PublishFlags.String() returned malformed string: %q", s)
 		}

--- a/publishiflags_test.go
+++ b/publishiflags_test.go
@@ -11,12 +11,16 @@ package avahi
 
 import "testing"
 
+// TestPublishFlagsString verifies correct string output for
+// individual flags and common flag combinations.
 func TestPublishFlagsString(t *testing.T) {
 	tests := []struct {
 		flags PublishFlags
 		want  string
 	}{
+		// No flags should produce an empty string
 		{0, ""},
+		// Individual flags
 		{PublishUnique, "unique"},
 		{PublishNoProbe, "no-probe"},
 		{PublishNoAnnounce, "no-announce"},
@@ -26,6 +30,7 @@ func TestPublishFlagsString(t *testing.T) {
 		{PublishUpdate, "update"},
 		{PublishUseWideArea, "use-wan"},
 		{PublishUseMulticast, "use-mdns"},
+		// Common flag combinations
 		{PublishUnique | PublishNoProbe, "unique,no-probe"},
 		{PublishUpdate | PublishUseWideArea, "update,use-wan"},
 	}

--- a/publishiflags_test.go
+++ b/publishiflags_test.go
@@ -1,0 +1,38 @@
+// CGo binding for Avahi
+//
+// Copyright (C) 2025 by Prashant Andoriya
+// See LICENSE for license terms and conditions
+//
+// Unit tests for PublishFlags string formatting
+//
+//go:build linux || freebsd
+
+package avahi
+
+import "testing"
+
+func TestPublishFlagsString(t *testing.T) {
+	tests := []struct {
+		flags PublishFlags
+		want  string
+	}{
+		{0, ""},
+		{PublishUnique, "unique"},
+		{PublishNoProbe, "no-probe"},
+		{PublishNoAnnounce, "no-announce"},
+		{PublishAllowMultiple, "allow-multiple"},
+		{PublishNoReverse, "no-reverse"},
+		{PublishNoCookie, "no-cookie"},
+		{PublishUpdate, "update"},
+		{PublishUseWideArea, "use-wan"},
+		{PublishUseMulticast, "use-mdns"},
+		{PublishUnique | PublishNoProbe, "unique,no-probe"},
+		{PublishUpdate | PublishUseWideArea, "update,use-wan"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.flags.String(); got != tt.want {
+			t.Fatalf("flags=%v: got %q, want %q", tt.flags, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR improves test coverage and robustness of go-avahi by adding unit tests and Go native fuzz tests for core, self contained components that handle flags, enums, errors, and concurrency 

### What’s included

- Unit tests + fuzz tests for:
   - err.go
   - eventqueue.go 
   - protocol.go 
   - publishiflags.go  

### Test Results 

```bash 
fuzz: elapsed: 0s, gathering baseline coverage: 0/19 completed
fuzz: elapsed: 0s, gathering baseline coverage: 19/19 completed, now fuzzing with 8 workers
fuzz: elapsed: 3s, execs: 461247 (153574/sec), new interesting: 7 (total: 26)
fuzz: elapsed: 6s, execs: 945127 (161444/sec), new interesting: 8 (total: 27)
fuzz: elapsed: 9s, execs: 1430134 (161683/sec), new interesting: 8 (total: 27)
fuzz: elapsed: 12s, execs: 1918480 (162785/sec), new interesting: 8 (total: 27)
fuzz: elapsed: 15s, execs: 2412459 (164652/sec), new interesting: 8 (total: 27)
fuzz: elapsed: 18s, execs: 2906178 (164566/sec), new interesting: 8 (total: 27)
fuzz: elapsed: 21s, execs: 3385588 (159798/sec), new interesting: 8 (total: 27)
fuzz: elapsed: 24s, execs: 3867545 (160528/sec), new interesting: 8 (total: 27)
fuzz: elapsed: 27s, execs: 4359421 (164105/sec), new interesting: 8 (total: 27)
fuzz: elapsed: 30s, execs: 4837652 (159286/sec), new interesting: 8 (total: 27)
fuzz: elapsed: 30s, execs: 4837652 (0/sec), new interesting: 8 (total: 27)
PASS
ok      github.com/OpenPrinting/go-avahi        30.074s
fuzz: elapsed: 0s, gathering baseline coverage: 0/25 completed
fuzz: elapsed: 0s, gathering baseline coverage: 25/25 completed, now fuzzing with 8 workers
fuzz: elapsed: 3s, execs: 457246 (152416/sec), new interesting: 6 (total: 31)
fuzz: elapsed: 6s, execs: 917492 (153404/sec), new interesting: 6 (total: 31)
fuzz: elapsed: 9s, execs: 1348841 (143749/sec), new interesting: 6 (total: 31)
fuzz: elapsed: 12s, execs: 1748030 (133058/sec), new interesting: 6 (total: 31)
fuzz: elapsed: 15s, execs: 2152960 (134967/sec), new interesting: 6 (total: 31)
fuzz: elapsed: 18s, execs: 2554512 (133867/sec), new interesting: 6 (total: 31)
fuzz: elapsed: 21s, execs: 2969037 (138182/sec), new interesting: 6 (total: 31)
fuzz: elapsed: 24s, execs: 3380303 (137078/sec), new interesting: 6 (total: 31)
fuzz: elapsed: 27s, execs: 3767614 (129107/sec), new interesting: 6 (total: 31)
fuzz: elapsed: 30s, execs: 4185483 (139066/sec), new interesting: 6 (total: 31)
fuzz: elapsed: 30s, execs: 4185483 (0/sec), new interesting: 6 (total: 31)
PASS
ok      github.com/OpenPrinting/go-avahi        30.103s
prashant@LAPTOP-PBG53FVG:/mnt/d/go-avahi$ go test -run=^$ -fuzz=^FuzzErrCodeError$ -fuzztime=30s
fuzz: elapsed: 0s, gathering baseline coverage: 0/19 completed
fuzz: elapsed: 0s, gathering baseline coverage: 19/19 completed, now fuzzing with 8 workers
fuzz: elapsed: 3s, execs: 466870 (155573/sec), new interesting: 10 (total: 29)
fuzz: elapsed: 6s, execs: 947648 (160287/sec), new interesting: 10 (total: 29)
fuzz: elapsed: 9s, execs: 1439013 (163808/sec), new interesting: 10 (total: 29)
fuzz: elapsed: 12s, execs: 1931004 (163981/sec), new interesting: 10 (total: 29)
fuzz: elapsed: 15s, execs: 2403840 (157616/sec), new interesting: 10 (total: 29)
fuzz: elapsed: 18s, execs: 2895459 (163851/sec), new interesting: 10 (total: 29)
fuzz: elapsed: 21s, execs: 3367099 (157237/sec), new interesting: 10 (total: 29)
fuzz: elapsed: 24s, execs: 3815351 (149408/sec), new interesting: 10 (total: 29)
fuzz: elapsed: 27s, execs: 4245021 (143228/sec), new interesting: 10 (total: 29)
fuzz: elapsed: 30s, execs: 4647713 (134246/sec), new interesting: 10 (total: 29)
fuzz: elapsed: 30s, execs: 4647713 (0/sec), new interesting: 10 (total: 29)
PASS
ok      github.com/OpenPrinting/go-avahi        30.104s
prashant@LAPTOP-PBG53FVG:/mnt/d/go-avahi$ go test -run=^$ -fuzz=^FuzzEventQueueOperations$ -fuzztime=30s
fuzz: elapsed: 0s, gathering baseline coverage: 0/61 completed
fuzz: elapsed: 0s, gathering baseline coverage: 61/61 completed, now fuzzing with 8 workers
fuzz: elapsed: 3s, execs: 351481 (117084/sec), new interesting: 22 (total: 83)
fuzz: elapsed: 6s, execs: 716108 (121483/sec), new interesting: 22 (total: 83)
fuzz: elapsed: 9s, execs: 1064524 (116246/sec), new interesting: 23 (total: 84)
fuzz: elapsed: 12s, execs: 1421275 (118915/sec), new interesting: 23 (total: 84)
fuzz: elapsed: 15s, execs: 1765527 (114771/sec), new interesting: 23 (total: 84)
fuzz: elapsed: 18s, execs: 2108337 (114250/sec), new interesting: 23 (total: 84)
fuzz: elapsed: 21s, execs: 2407019 (99466/sec), new interesting: 24 (total: 85)
fuzz: elapsed: 24s, execs: 2712334 (101840/sec), new interesting: 24 (total: 85)
fuzz: elapsed: 27s, execs: 3009958 (99183/sec), new interesting: 24 (total: 85)
fuzz: elapsed: 30s, execs: 3313329 (101200/sec), new interesting: 24 (total: 85)
fuzz: elapsed: 30s, execs: 3313329 (0/sec), new interesting: 24 (total: 85)
PASS
ok      github.com/OpenPrinting/go-avahi        30.107s



