### PR TITLE
docs: clarify Poll context cancellation return valueClarify poller source removal

### DIFF
--- a/poller.go
+++ b/poller.go
@@ -37,6 +37,8 @@ func NewPoller() *Poller {
 //   - nil, error - if context is canceled
 //   - event, nil - if event is available
 //
+// If an event source channel is closed, it is automatically removed
+// from the Poller and polling continues with remaining sources.
 // The returned event is one of the following:
 //   - [*ClientEvent]
 //   - [*DomainBrowserEvent]

--- a/poller.go
+++ b/poller.go
@@ -34,8 +34,8 @@ func NewPoller() *Poller {
 // Poll waits for the next event from any of registered sources.
 //
 // It returns:
-//   - nil, error - if context is canceled
-//   - event, nil - if event is available
+//   - nil, ctx.Err() - if the context is canceled or its deadline expires
+//   - event, nil    - if an event is available
 //
 // The returned event is one of the following:
 //   - [*ClientEvent]

--- a/poller.go
+++ b/poller.go
@@ -37,8 +37,6 @@ func NewPoller() *Poller {
 //   - nil, error - if context is canceled
 //   - event, nil - if event is available
 //
-// If an event source channel is closed, it is automatically removed
-// from the Poller and polling continues with remaining sources.
 // The returned event is one of the following:
 //   - [*ClientEvent]
 //   - [*DomainBrowserEvent]
@@ -52,6 +50,9 @@ func NewPoller() *Poller {
 // If source is added while Poll is active, it may or may not affect
 // the pending Poll, no guarantees are provided here except for safety
 // guarantees.
+//
+// If an event source channel is closed, it is automatically removed
+// from the Poller and polling continues with remaining sources.
 //
 // Events, received from the same source, are never reordered between
 // each other, but events from different sources may be reordered.


### PR DESCRIPTION
### What this PR does
- Clarifies the exact return value of Poll when the context is canceled

### Why this is needed
- Makes the API contract more precise by documenting that ctx.Err() is returned

### Scope
- Documentation only
- No functional changes

### Testing
- go test ./...