### PR TITLE
dns: validate AddrFromSlice result when decoding records

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -57,8 +57,9 @@ const (
 func DNSDecodeA(rdata []byte) netip.Addr {
 	var addr netip.Addr
 	if len(rdata) == 4 {
-		addr, _ = netip.AddrFromSlice(rdata)
-		addr = addr.Unmap()
+		if a, ok := netip.AddrFromSlice(rdata); ok {
+			addr = a.Unmap()
+		}
 	}
 	return addr
 }
@@ -70,7 +71,9 @@ func DNSDecodeA(rdata []byte) netip.Addr {
 func DNSDecodeAAAA(rdata []byte) netip.Addr {
 	var addr netip.Addr
 	if len(rdata) == 16 {
-		addr, _ = netip.AddrFromSlice(rdata)
+		if a, ok := netip.AddrFromSlice(rdata); ok {
+			addr = a
+		}
 	}
 	return addr
 }


### PR DESCRIPTION
### What this PR does
- Validates the result of netip.AddrFromSlice when decoding A and AAAA records

### Why this is needed
- Improves defensive correctness when handling malformed rdata
- Does not change public behavior or APIs

### Scope
- Internal decoding logic only
- No API changes

### Testing
- go test ./...